### PR TITLE
Update development_guide.md

### DIFF
--- a/docs/development/development_guide.md
+++ b/docs/development/development_guide.md
@@ -54,4 +54,4 @@ We have a convienent alias for this, run `cm`
 
 ## Run some code
 Now that the repository is built, try running something!
-`roslaunch navigator_launch simulator.launch`
+`roslaunch navigator_launch simulation.launch`


### PR DESCRIPTION
Fixed Typo in development guide proposed command for running the simulator from:
`roslaunch navigator_launch simulator.launch`
to:
`roslaunch navigator_launch simulation.launch`